### PR TITLE
Edited terminal print output options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Introduction
 
 :maxsmooth: Derivative Constrained Function Fitting
 :Author: Harry Thomas Jones Bevins
-:Version: 1.2.0
+:Version: 1.2.1
 :Homepage: https://github.com/htjb/maxsmooth
 :Documentation: https://maxsmooth.readthedocs.io/
 

--- a/maxsmooth/qp.py
+++ b/maxsmooth/qp.py
@@ -11,7 +11,7 @@ warnings.simplefilter('always', UserWarning)
 class qp_class(object):
     def __init__(
             self, x, y, N, signs, pivot_point, model_type, cvxopt_maxiter,
-            all_output, zero_crossings, initial_params,
+            zero_crossings, initial_params,
             constraints, new_basis):
         self.model_type = model_type
         self.pivot_point = pivot_point
@@ -20,7 +20,6 @@ class qp_class(object):
         self.N = N
         self.signs = signs
         self.cvxopt_maxiter = cvxopt_maxiter
-        self.all_output = all_output
         self.zero_crossings = zero_crossings
         self.initial_params = initial_params
         self.basis_functions = new_basis['basis_function']

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme(short=False):
 
 setup(
     name='maxsmooth',
-    version='1.2.0',
+    version='1.2.1',
     description='maxsmooth:Derivative Constrained Function Fitting',
     long_description=readme(),
     author='Harry T. J. Bevins',

--- a/tests/test_smooth.py
+++ b/tests/test_smooth.py
@@ -64,7 +64,7 @@ def test_keywords():
     with pytest.raises(Exception):
         sol = smooth(x, y, N, cvxopt_maxiter=41.2)
     with pytest.raises(Exception):
-        sol = smooth(x, y, N, all_output=9)
+        sol = smooth(x, y, N, print_output=9)
     with pytest.raises(Exception):
         sol = smooth(x, y, N, data_save='string')
     with pytest.raises(Exception):
@@ -95,7 +95,7 @@ def test_smooth_fit():
     y = 1 + x + x**2 + x**3
 
     N = 4
-    sol = smooth(x, y, N, model_type='polynomial', all_output=True)
+    sol = smooth(x, y, N, model_type='polynomial', print_output=2)
 
     assert_almost_equal(sol.optimum_params.T[0], [1, 1, 1, 1], decimal=3)
 
@@ -106,7 +106,7 @@ def test_smooth_fit():
 
     sol = smooth(
         x, y, N, model_type='polynomial', fit_type='qp',
-        all_output=True)
+        print_output=2)
 
     assert(sol.cap is None)
     assert_almost_equal(sol.optimum_params.T[0], [1, 1, 1, 1], decimal=3)
@@ -134,7 +134,7 @@ def test_output_directional_exp():
     y = 5e7*x**(-2.5)
 
     N = 10
-    sol = smooth(x, y, N, model_type='legendre', all_output=True)
+    sol = smooth(x, y, N, model_type='legendre', print_output=0)
 
     assert_almost_equal( sol.optimum_chi , ((y - sol.y_fit)**2).sum())
 
@@ -322,14 +322,14 @@ def test_ifp():
     N = 10
 
     sol = smooth(
-        x, y, N, zero_crossings=[4, 5, 6], constraints=1, all_output=True)
+        x, y, N, zero_crossings=[4, 5, 6], constraints=1, print_output=0)
 
     assert(len(sol.optimum_zc_dict) == 4)
     assert(type(sol.optimum_zc_dict) is dict)
 
     sol = smooth(
         x, y, N, zero_crossings=[4, 5, 6],
-        constraints=1, all_output=True, fit_type='qp')
+        constraints=1, print_output=2, fit_type='qp')
 
     assert(len(sol.optimum_zc_dict) == 4)
     assert(type(sol.optimum_zc_dict) is dict)


### PR DESCRIPTION
Removed the kwarg `all_output` and replaced this with a new kwarg `print_output` which can have a value in the set `[0, 1, 2]`. This allows the user to print out to the terminal the full set of fits performed by `maxsmooth` (`print_output=2`), just the optimum result(`print_output=1`) or nothing(`print_output=0`). 

In each case the optimum result is saved to disc and it can be useful to limit what is printed by `maxsmooth` in some instances to make the terminal output of other code readable. For example when wrapping `maxsmooth` inside other fitting algorithms (e.g. nested sampling codes like `polychord`).
